### PR TITLE
Rotas  Pessoa : Exclusão de dados e Consulta ; Orquestrador : Exclusão de dados de Pessoa

### DIFF
--- a/orquestrador/orquestrador.py
+++ b/orquestrador/orquestrador.py
@@ -101,6 +101,38 @@ class Orquestrador(object):
     def excluir_pessoa(self, pessoa_id_usuario):
             # simulando retorno OK
         return True
+    
+    
+    
+    def excluir_dados_pessoa(self, segredo, dados):
+        
+        try:
+            if (self.conexao_bd.Pessoas.find({"_id": ObjectId(segredo)}).limit(1).count() > 0):
+
+                print("\n[Orquestrador] Exclusão de dados:\n" + str(dados))
+
+                try:
+                    self.conexao_bd.Pessoas.update(
+                    {"_id": ObjectId(segredo)}, {"$unset": dados}), False, True
+
+                except Exception as e:
+                    print(e)
+                    raise Exception(StatusInternos(
+                    "SI-8", {"colecao": "Pessoas", "momento": "Excluir dados", "dados excluídos": dados,
+                         "segredo": segredo}))
+
+            else:
+                raise Exception(StatusInternos(
+                "SI-8", {"colecao": "Pessoas", "momento": "Excluir dados", "dados excluídos": dados,
+                     "segredo": segredo}))
+
+        except Exception as e:
+            print(e)
+            raise Exception(StatusInternos(
+                "SI-4", {"colecao": "Pessoas", "momento": "Excluir dados", "dados excluídos": dados}))
+            
+            
+    
 
     def login_pessoa(self, valor_login, senha, tipo):
         # Login por cpf

--- a/rotas/pessoa.py
+++ b/rotas/pessoa.py
@@ -177,7 +177,7 @@ def Consultar_Pessoa() :
         json_retorno = RespostasAPI('Consulta realizada com sucesso',
                                 {
                                     'segredo': str(segredo),
-                                    'dados de ' + str(retorno['nome_completo']) : str(retorno),
+                                    'dados': str(retorno),
                                 }
                                 ).JSON
 
@@ -203,7 +203,7 @@ def ExcluirDados_Pessoa():
         json_retorno = RespostasAPI('Exclusão realizada com sucesso',
                                 {
                                     'segredo': str(segredo),
-                                    'Dados excluídos:' : str(dados_excluidos),
+                                    'dados' : str(dados_excluidos),
                                 }
                                 ).JSON
 

--- a/rotas/pessoa.py
+++ b/rotas/pessoa.py
@@ -160,3 +160,54 @@ def AdicionarDados_Pessoa():
 
     except StatusInternos as e:
         return e.errors
+    
+## ---------------------------------------------------------
+## Endpoint de consulta de Pessoa
+## ---------------------------------------------------------
+
+    
+@blueprint_pessoa.route("/consultar", methods=['GET'])
+def Consultar_Pessoa() :
+    consulta_pessoa = request.json
+    segredo = consulta_pessoa['_id']
+    print("\n[Requisição-GET] /Consultar dados Pessoa:\n" + str(consulta_pessoa) + "\n")
+    try:
+        retorno = orq.verificar_id_usuario(segredo)
+
+        json_retorno = RespostasAPI('Consulta realizada com sucesso',
+                                {
+                                    'segredo': str(segredo),
+                                    'dados de ' + str(retorno['nome_completo']) : str(retorno),
+                                }
+                                ).JSON
+
+        return json_retorno
+    except StatusInternos as e:
+        return e.errors
+
+## ---------------------------------------------------------
+## Endpoint de exclusão de dados de Pessoa
+## ---------------------------------------------------------
+
+@blueprint_pessoa.route("/excluir_dados", methods=['DELETE'])
+@schema.validate(schemaEdicao)
+def ExcluirDados_Pessoa():
+
+    excluir_dados_request = request.json
+    segredo = excluir_dados_request['_id']
+    dados_excluidos = excluir_dados_request['dados_excluidos']
+    print("\n[Requisição-DELETE] /Excluir Dados:\n" + str(excluir_dados_request) + "\n")
+    try:
+        orq.excluir_dados_pessoa(segredo,dados_excluidos)
+
+        json_retorno = RespostasAPI('Exclusão realizada com sucesso',
+                                {
+                                    'segredo': str(segredo),
+                                    'Dados excluídos:' : str(dados_excluidos),
+                                }
+                                ).JSON
+
+        return json_retorno
+
+    except StatusInternos as e:
+        return e.errors


### PR DESCRIPTION
Inclusão de rotas para consulta e exclusão de dados de Pessoa.

A função de exclusão remove do banco somente os dados que vierem na requisição HTTP, os dados deverão estar contidos dentro do campo "dados_excluidos", após o campo "_id".

Exemplo de exclusão de dados de Pessoa:

Exclusão do campo "nacionalidade"

{"_id" : "1234567e9",
"dados_excluidos" : {
"nacionalidade" : "Brasileira"
}
}
